### PR TITLE
Added support for Adapt.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,7 @@ GPUArrays 0.2.0
 StaticArrays
 ColorTypes
 
+Adapt
 Transpiler 0.4.3
 Sugar 0.4.1
 Matcha 0.1.1

--- a/src/CLArrays.jl
+++ b/src/CLArrays.jl
@@ -17,6 +17,6 @@ include("context.jl")
 include("compilation.jl")
 include("3rdparty.jl")
 
-export CLArray, gpu_call, is_gpu, is_cpu
+export CLArray, gpu_call, is_gpu, is_cpu, cl
 
 end # module

--- a/src/CLArrays.jl
+++ b/src/CLArrays.jl
@@ -17,6 +17,6 @@ include("context.jl")
 include("compilation.jl")
 include("3rdparty.jl")
 
-export CLArray, gpu_call, is_gpu, is_cpu, cl
+export CLArray, gpu_call, is_gpu, is_cpu
 
 end # module

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,10 +26,16 @@ context(p::CLArray) = context(pointer(p))
 
 # Avoid conflict with OpenCL.cl
 module Shorthands
-    using ..CLArrays
-    cl(x) = x
-    cl(x::CLArrays.CLArray) = x
-    cl(xs::AbstractArray) = isbits(xs) ? xs : CLArrays.CLArray(xs)
+    using ..CLArray
+    import Adapt: adapt, adapt_
+
+    adapt_(::Type{<:CLArray}, xs::AbstractArray) = isbits(xs) ? xs : convert(CLArray, xs)
+    adapt_(::Type{<:CLArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
+        isbits(xs) ? xs : convert(CLArray{T}, xs)
+
+    cl(x) = adapt(x)
+
+    export cl
 end
 
 function (::Type{CLArray{T, N}})(size::NTuple{N, Integer}, ctx::cl.Context = global_context()) where {T, N}
@@ -119,11 +125,3 @@ function copy!{T}(
     )
     dest
 end
-
-import Adapt: adapt, adapt_
-
-adapt_(::Type{<:CLArray}, xs::AbstractArray) = isbits(xs) ? xs : convert(CLArray, xs)
-adapt_(::Type{<:CLArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
-    isbits(xs) ? xs : convert(CLArray{T}, xs)
-
-cl(x) = adapt(CLArray{Float32}, x)

--- a/src/array.jl
+++ b/src/array.jl
@@ -119,3 +119,11 @@ function copy!{T}(
     )
     dest
 end
+
+import Adapt: adapt, adapt_
+
+adapt_(::Type{<:CLArray}, xs::AbstractArray) = isbits(xs) ? xs : convert(CLArray, xs)
+adapt_(::Type{<:CLArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
+    isbits(xs) ? xs : convert(CLArray{T}, xs)
+
+cl(x) = adapt(CLArray{Float32}, x)

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,12 +26,12 @@ context(p::CLArray) = context(pointer(p))
 
 # Avoid conflict with OpenCL.cl
 module Shorthands
-    using ..CLArray
+    using ..CLArrays: CLArray
     import Adapt: adapt, adapt_
 
     adapt_(::Type{<:CLArray}, xs::AbstractArray) = isbits(xs) ? xs : convert(CLArray, xs)
 
-    cl(x) = adapt(x)
+    cl(x) = adapt(CLArray{Float32}, x)
 
     export cl
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -30,8 +30,6 @@ module Shorthands
     import Adapt: adapt, adapt_
 
     adapt_(::Type{<:CLArray}, xs::AbstractArray) = isbits(xs) ? xs : convert(CLArray, xs)
-    adapt_(::Type{<:CLArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
-        isbits(xs) ? xs : convert(CLArray{T}, xs)
 
     cl(x) = adapt(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using CLArrays
+using CLArrays, CLArrays.Shorthands
 using GPUArrays.TestSuite, Base.Test
 
 for dev in CLArrays.devices()
@@ -29,6 +29,13 @@ for dev in CLArrays.devices()
             # this version needs to have a fix in GPUArrays, since it uses T.(array)
             # in copy to convert to array type, but that actually convert Array{Bool} to BitArray
             # against_base((a, b)-> a .& b, CLArray{Bool}, (10,), (10,))
+        end
+
+        @testset "Shorthand Test" begin
+            GPUArrays.allowslow(true)
+            @test collect(cl([1,2])) == [1,2]
+            @test collect(cl([1 2;3 4])) == [1 2;3 4]
+            @test cl([1,2,3]) == CLArray([1,2,3])
         end
     end
 end
@@ -132,4 +139,3 @@ end
 #     # out[15] = sizeof(x15)
 #     return
 # end
-


### PR DESCRIPTION
In line to what is was already done for CuArrays, I've added support for Adapt in CLArrays and also created a `cl` function that works similarly to the `cu` function in CuArrays. 

Please let me know if you want me to add tests. 