### PR TITLE
Remove dependencies from Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,6 @@ variables:
 .test_template: &test_definition
   before_script:
     - apt-get -qq update && apt-get -qq install -y libclblas-dev libclfft-dev
-    - apt-get install --reinstall -y ca-certificates
-    - apt-get install --reinstall -y openssl
 
   script:
     - julia -e 'versioninfo()'


### PR DESCRIPTION
Let's see if this works.

@SimonDanisch do note that the `before_install` step runs before every job, so if you ever split into jobs better add those rules to only the job that actually tests.